### PR TITLE
Fix implicit type specifier errors

### DIFF
--- a/util/rarian-example.c
+++ b/util/rarian-example.c
@@ -77,6 +77,7 @@ for_each_cb (RrnReg *reg, void * user_data)
     return TRUE;
 }
 
+int
 info_for_each (RrnInfoEntry *entry, void *data)
 {
   if (entry->section)
@@ -90,6 +91,7 @@ info_for_each (RrnInfoEntry *entry, void *data)
   return TRUE;
 }
 
+int
 man_for_each (RrnManEntry *entry, void *data)
 {
   printf ("Man page %s\n", entry->name);


### PR DESCRIPTION
explicit int type specifier to resolve:
80:1: error: type specifier missing, defaults to 'int' 93:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]